### PR TITLE
hello, why no callback method when the ads disappear?

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ API Reference can be found [here](https://github.com/Unity-Technologies/unity-ad
 ## Transition guide from Unity Ads 1.5
 
 Transition guide from Unity Ads 1.5 can be found [here](https://github.com/Unity-Technologies/unity-ads-ios/wiki/sdk_ios_transition_guide)
+
+azurebld@qq.com


### PR DESCRIPTION
i am still using old v1.5 sdk and plan to migrate to the new v2 sdk. With old sdk, there's a pair of delegate methods "unityAdsDidShow" & "unityAdsDidHide" that i can use to pause & resume game/music/other things. With new sdk, "unityAdsDidStart" can substitute "unityAdsDidShow", but there's no substitution for "unityAdsDidHide". "unityAdsDidFinish" wont do the work, it works like old "unityAdsVideoCompleted".

So may you add the callback method back?
