### PR TITLE
xcode debug log area is spammed by unity ads sdk logs

### DIFF
--- a/UnityAds/UnityAds.m
+++ b/UnityAds/UnityAds.m
@@ -160,7 +160,7 @@ static BOOL _initializing = NO;
     if(_debugMode) {
         [UADSDeviceLog setLogLevel:kUnityAdsLogLevelDebug];
     } else {
-        [UADSDeviceLog setLogLevel:kUnityAdsLogLevelInfo];
+        [UADSDeviceLog setLogLevel:kUnityAdsLogLevelWarning];
     }
 }
 


### PR DESCRIPTION
make debug-off-mode log-level to errors/warning, not info,
or change many improper UADSLogInfo to UADSLogDebug