### PR TITLE
Store the view controller used for presentation as a weak variable

### DIFF
--- a/UnityAds/Properties/UADSClientProperties.m
+++ b/UnityAds/Properties/UADSClientProperties.m
@@ -4,7 +4,7 @@
 @implementation UADSClientProperties
 
 static NSString *_gameId = @"-1";
-__unsafe_unretained static UIViewController *_currentViewController = nil;
+__weak static UIViewController *_currentViewController = nil;
 static id<UnityAdsDelegate> _delegate = nil;
 
 + (void)setGameId:(NSString *)gid {


### PR DESCRIPTION
Unity Ads SDK requires a view controller to present the ad view controller from. This view controller is set via the `+[UnityAds show:]` and the `+[UnityAds show:placementId:]` methods and eventually gets passed down to `+[UADSClientProperties setCurrentViewController:]`, which, in turn, stores the view controller in an [`__unsafe_unretained` global static variable](https://github.com/Unity-Technologies/unity-ads-ios/blob/master/UnityAds/Properties/UADSClientProperties.m#L7).

This approach, while indeed not affecting the lifetime of the presenting view controller in any way, does present an opportunity for a crash due to messaging a dangling pointer to the presenting view controller.

Since both `+[UnityAds show:]` methods are asynchronous, the actual ad presentation will occur sometime after these methods return, and definitely not in the same runloop cycle, which leaves enough time for the presenting view controller to be deallocated (for example, if the user navigates away from the presenting view controller quickly enough). By the time `[UADSApiAdUnit WebViewExposed_open:supportedOrientations:statusBarHidden:shouldAutorotate:isTransparent:withAnimation:callback:]` is called to perform the actual presentation, `_currentViewController` would have already become a dangling pointer, and a crash (or unexpected behavior) is unavoidable.

The minimal and trivial fix would be to mark the `_currentViewController` variable as `__weak` instead of `__unsafe_unretained`. This would preserve the non-retaining behavior, but will also prevent the kind of crashes described above. This PR does exactly that.

A more comprehensive approach would probably be to provide a way to cancel the requested, but not yet executed, ad presentation via a new `cancelPresentation` method on the `UnityAds` class. That method would cancel the in-flight `UADSWebViewShowOperation` and safely reset the `_currentViewController` to `nil`. The clients would then be able to call this cancellation method before navigating away from the presenting view controller.

