### PR TITLE
FIX setMaxConcurrentOperationCount: crash with negative int values

### DIFF
--- a/UnityAds/Request/UADSWebRequestQueue.m
+++ b/UnityAds/Request/UADSWebRequestQueue.m
@@ -23,7 +23,7 @@ static dispatch_once_t onceToken;
 }
 
 + (void)setConcurrentRequestCount: (int) count {
-    requestQueue.maxConcurrentOperationCount = count;
+    requestQueue.maxConcurrentOperationCount = MAX(1, count);
 }
 
 + (void)requestUrl:(NSString *)url type:(NSString *)type headers:(NSDictionary<NSString*, NSArray*> *)headers completeBlock:(UnityAdsWebRequestCompletion)completeBlock connectTimeout:(int)connectTimeout {


### PR DESCRIPTION
UADSWKWebViewApp can invokes setConcurrentRequestCount: with negative int values. In this case bellow crash occurs:
```objective-c
2018-08-14 09:43:33.984288+0300 SampleApp[3679:48364] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSOperationQueue setMaxConcurrentOperationCount:]: count (-1532458671) cannot be negative'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000111bfa58b __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x000000011752ba0d objc_exception_throw + 48
	2   CoreFoundation                      0x0000000111bfa3e5 +[NSException raise:format:] + 197
	3   Foundation                          0x0000000113a3fcb5 -[NSOperationQueue setMaxConcurrentOperationCount:] + 82
	4   ExampleAppodeal                     0x000000010dcdbf73 +[UADSApiRequest WebViewExposed_setConcurrentRequestCount:callback:] + 62
	5   CoreFoundation                      0x0000000111c0143c __invoking___ + 140
	6   CoreFoundation                      0x0000000111bfe8c5 -[NSInvocation invoke] + 325
	7   ExampleAppodeal                     0x000000010dcfbed7 -[UADSInvocation nextInvocation] + 220
	8   ExampleAppodeal                     0x000000010dcfdd55 -[UADSWebViewMethodInvokeHandler handleInvocation:] + 1324
	9   ExampleAppodeal                     0x000000010dcfd7ba -[UADSWebViewMethodInvokeHandler handleData:invocationType:] + 661
	10  ExampleAppodeal                     0x000000010dcfa487 -[UADSWKWebViewApp userContentController:didReceiveScriptMessage:] + 340
	11  WebKit                              0x0000000116ecf250 _ZN28ScriptMessageHandlerDelegate14didPostMessageERN6WebKit12WebPageProxyERKNS0_13FrameInfoDataERN7WebCore21SerializedScriptValueE + 190
	12  WebKit                              0x0000000116e65d38 _ZN6WebKit29WebUserContentControllerProxy14didPostMessageERN3IPC10ConnectionEyRKNS_13FrameInfoDataEyRKNS1_13DataReferenceE + 178
	13  WebKit                              0x0000000116e685b3 _ZN3IPC13handleMessageIN8Messages29WebUserContentControllerProxy14DidPostMessageEN6WebKit29WebUserContentControllerProxyEMS5_FvRNS_10ConnectionEyRKNS4_13FrameInfoDataEyRKNS_13DataReferenceEEEEvS7_RNS_7DecoderEPT0_T1_ + 243
	14  WebKit                              0x0000000116ba1bd5 _ZN3IPC18MessageReceiverMap15dispatchMessageERNS_10ConnectionERNS_7DecoderE + 127
	15  WebKit                              0x0000000116e07786 _ZN6WebKit15WebProcessProxy17didReceiveMessageERN3IPC10ConnectionERNS1_7DecoderE + 24
	16  WebKit                              0x0000000116b684b7 _ZN3IPC10Connection15dispatchMessageENSt3__110unique_ptrINS_7DecoderENS1_14default_deleteIS3_EEEE + 119
	17  WebKit                              0x0000000116b68bd2 _ZN3IPC10Connection24dispatchIncomingMessagesEv + 730
	18  JavaScriptCore                      0x0000000114659377 _ZN3WTF7RunLoop11performWorkEv + 231
	19  JavaScriptCore                      0x0000000114659602 _ZN3WTF7RunLoop11performWorkEPv + 34
	20  CoreFoundation                      0x0000000111b5e251 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
	21  CoreFoundation                      0x0000000111b5dac3 __CFRunLoopDoSources0 + 243
	22  CoreFoundation                      0x0000000111b5815f __CFRunLoopRun + 1263
	23  CoreFoundation                      0x0000000111b57931 CFRunLoopRunSpecific + 625
	24  GraphicsServices                    0x00000001197a91b5 GSEventRunModal + 62
	25  UIKitCore                           0x00000001216a72ce UIApplicationMain + 140
	26  ExampleAppodeal                     0x000000010cf88cd0 main + 112
	27  libdyld.dylib                       0x0000000118084c9d start + 1
	28  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

This pull request fix this behaviour on native objective-c code side