### PR TITLE
Fixed UnityAdsBanner delegate. It should be weak and nullable.

### DIFF
--- a/UnityServices/Banners/Properties/UADSBannerProperties.h
+++ b/UnityServices/Banners/Properties/UADSBannerProperties.h
@@ -1,7 +1,13 @@
 #import "UADSBanner.h"
 
-@interface UADSBannerProperties : NSObject
-+(id <UnityAdsBannerDelegate>)getDelegate;
+NS_ASSUME_NONNULL_BEGIN
 
-+(void)setDelegate:(id <UnityAdsBannerDelegate>)delegate;
+@interface UADSBannerProperties : NSObject
+
++(nullable id <UnityAdsBannerDelegate>)getDelegate;
+
++(void)setDelegate:(nullable id <UnityAdsBannerDelegate>)delegate;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UnityServices/Banners/Properties/UADSBannerProperties.m
+++ b/UnityServices/Banners/Properties/UADSBannerProperties.m
@@ -1,13 +1,14 @@
 #import "UADSBannerProperties.h"
 
 @implementation UADSBannerProperties
-static id <UnityAdsBannerDelegate> s_bannerDelegate;
 
-+(void)setDelegate:(id <UnityAdsBannerDelegate>)delegate {
+static __weak id <UnityAdsBannerDelegate> _Nullable s_bannerDelegate;
+
++(void)setDelegate:(nullable id <UnityAdsBannerDelegate>)delegate {
     s_bannerDelegate = delegate;
 }
 
-+(id <UnityAdsBannerDelegate>)getDelegate {
++(nullable id <UnityAdsBannerDelegate>)getDelegate {
     return s_bannerDelegate;
 }
 

--- a/UnityServices/Banners/UADSBanner.h
+++ b/UnityServices/Banners/UADSBanner.h
@@ -101,7 +101,7 @@ typedef NS_ENUM(NSInteger, UnityAdsBannerPosition) {
  *
  *  @param delegate The new `UnityAdsBannerDelegate' for UnityAds to send banner callbacks to.
  */
-+(void)setDelegate:(id <UnityAdsBannerDelegate>)delegate;
++(void)setDelegate:(nullable id <UnityAdsBannerDelegate>)delegate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnityServices/Banners/UADSBanner.m
+++ b/UnityServices/Banners/UADSBanner.m
@@ -44,11 +44,11 @@
     [USRVWebViewMethodInvokeQueue addOperation:operation];
 }
 
-+(id <UnityAdsBannerDelegate>)getDelegate {
++(nullable id <UnityAdsBannerDelegate>)getDelegate {
     return [UADSBannerProperties getDelegate];
 }
 
-+(void)setDelegate:(id <UnityAdsBannerDelegate>)delegate {
++(void)setDelegate:(nullable id <UnityAdsBannerDelegate>)delegate {
     [UADSBannerProperties setDelegate:delegate];
 }
 


### PR DESCRIPTION
There was no way (without warning) to set delegate to nil.
Also it shouldn't be a strong reference.