### PR TITLE
bug/Fix USTRProductRequest subscriptionPeriod crash on ios11.1 and below

### DIFF
--- a/UnityServices/Store/Transactions/USTRProductRequest.m
+++ b/UnityServices/Store/Transactions/USTRProductRequest.m
@@ -85,7 +85,7 @@ static NSMutableArray<USTRProductRequest*> *requests;
                     [productDict setObject:priceLocaleDict forKey:@"priceLocale"];
                 }
 
-                if ([product valueForKey:@"subscriptionPeriod"]) {
+                if ([product respondsToSelector: @selector(subscriptionPeriod)]) {
                     id subscriptionPeriod = [product valueForKey:@"subscriptionPeriod"];
                     NSUInteger numOfUnits = (NSUInteger)[subscriptionPeriod valueForKey:@"numberOfUnits"];
                     BOOL isSubscription = (subscriptionPeriod != nil) && (numOfUnits > 0);


### PR DESCRIPTION
This fixes a crash on iOS11.1 and below:

```Fatal Exception: NSUnknownKeyException
[<SKProduct 0x8484d50> valueForUndefinedKey:]: this class is not key value coding-compliant for the key subscriptionPeriod.

Fatal Exception: NSUnknownKeyException
0  CoreFoundation                 0x1e247b3d __exceptionPreprocess
1  libobjc.A.dylib                0x1d4cf067 objc_exception_throw
2  CoreFoundation                 0x1e24784f -[NSException init]
3  Foundation                     0x1eb51153 (Missing)
4  Foundation                     0x1eaa9505 (Missing)
5  mansion                        0x158ea51 -[USTRProductRequest sendProducts:invalidProducts:]
6  mansion                        0x158ef2f -[USTRProductRequest productsRequest:didReceiveResponse:]
7  StoreKit                       0x29a50ccf __34-[SKProductsRequest _handleReply:]_block_invoke
8  libdispatch.dylib              0x1d915797 _dispatch_call_block_and_release
9  libdispatch.dylib              0x1d915783 _dispatch_client_callout
10 libdispatch.dylib              0x1d919d05 _dispatch_main_queue_callback_4CF
11 CoreFoundation                 0x1e203d69 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
12 CoreFoundation                 0x1e201e19 __CFRunLoopRun```

Alternatively, you can do version checks like:

`if ( @available(iOS 11.1, *) ) { ... }`