### PR TITLE
Removing license from podspec

### DIFF
--- a/UnityAds.podspec
+++ b/UnityAds.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'UnityAds'
   s.version = '3.3.0'
-  s.license = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
+  s.license = { :type => 'Apache License, Version 2.0'}
   s.author = { 'UnityAds' => 'itunes@unity3d.com' }
   s.homepage = 'https://unity3d.com/services/ads'
   s.summary = 'Monetize your entire player base and reach new audiences with video ads.'


### PR DESCRIPTION
After a pod install, you get the following warning:
Unable to read the license file `LICENSE` for the spec `UnityAds (3.3.0)`
This happens because in the podspec a license is being declared, but then in the zipped source no license file is included.