### PR TITLE
[CocoaPods] Use XCFramework

### DIFF
--- a/UnityAds.podspec
+++ b/UnityAds.podspec
@@ -6,8 +6,8 @@ Pod::Spec.new do |s|
   s.homepage = 'https://unity3d.com/services/ads'
   s.summary = 'Monetize your entire player base and reach new audiences with video ads.'
   s.platform = :ios
-  s.source = { :http => 'https://github.com/Unity-Technologies/unity-ads-ios/releases/download/3.7.5/UnityAds.zip' }
+  s.source = { :http => 'https://github.com/Unity-Technologies/unity-ads-ios/releases/download/3.7.5/UnityAdsXCF.zip' }
   s.ios.deployment_target = '9.0'
-  s.ios.vendored_frameworks = 'UnityAds.framework'  
-  s.ios.xcconfig = { 'OTHER_LDFLAGS' => '-framework UnityAds' }
+  s.ios.vendored_frameworks = 'UnityAds.xcframework'
+  s.cocoapods_version = '>= 1.9.0'
 end


### PR DESCRIPTION
This is needed for Apple Silicon (M1) Mac users to build against arm64 simulator.

https://blog.cocoapods.org/CocoaPods-1.9.0-beta/